### PR TITLE
jQuery.animate complete callback triggered twice

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "copyright": "First+Third",
   "main": "dist/smooth-scroller.bower.js",
   "dependencies": {
-    "jquery": "~1.X"
+    "jquery": ">=1.6 ~1.x"
   },
   "devDependencies": {
     "assert": "*",

--- a/lib/smooth-scroller.js
+++ b/lib/smooth-scroller.js
@@ -7,7 +7,7 @@
 
     $(options.scrollEl).animate({
       scrollTop: el.offset().top - $(options.scrollEl).offset().top - options.offset
-    }, options.speed, options.ease, function() {
+    }, options.speed, options.ease).promise().done(function() {
       var hash = el.attr('id');
 
       if(hash.length) {


### PR DESCRIPTION
When scrolling using the default `scrollEl` (`'body,html'`) the jQuery.animate complete event will be triggered twice. This is correct behavior because two elements are being selected. However, this causes two entries to be made in the history. By moving to using promises for when the animation is complete the callback is only fired once.

A side effect of this is requiring at least jQuery 1.6 when Deferred/Promise support was added to jQuery.  
