### PR TITLE
call window.history.pushState before scroll animation so back button …

### DIFF
--- a/lib/smooth-scroller.js
+++ b/lib/smooth-scroller.js
@@ -1,21 +1,23 @@
 //smooth-scroller.js
 
-(function($) {
+(function(window, $) {
   $.fn.smoothScroller = function(options) {
     options = $.extend({}, $.fn.smoothScroller.defaults, options);
     var el = $(this);
+    var hash = el.attr('id');
+    var historySupport = window.history && window.history.pushState;
+
+    if (hash.length && historySupport) {
+      window.history.pushState(null, null, '#' + hash);
+    }
 
     $(options.scrollEl).animate({
       scrollTop: el.offset().top - $(options.scrollEl).offset().top - options.offset
     }, options.speed, options.ease, function() {
       var hash = el.attr('id');
 
-      if(hash.length) {
-        if(history.pushState) {
-          history.pushState(null, null, '#' + hash);
-        } else {
-          document.location.hash = hash;
-        }
+      if(hash.length && !historySupport) {
+        document.location.hash = hash;
       }
 
       el.trigger('smoothScrollerComplete');
@@ -39,4 +41,4 @@
       $(href).smoothScroller();
     }
   });
-}(jQuery));
+}(window, jQuery));


### PR DESCRIPTION
…goes to pre-scroll position.

Because `window.history.pushState` isn't called until _after_ the scroll is completed, the post-scroll window position is the prior state that is recorded. As such, hitting the browser's back-button will not return the window to the previous position. Moving the call to `pushState` before the animation fixes this.

Note: this pull does not fix this behavior in browsers without history API support. We can't manipulate `document.location.hash` before the animation as that would defeat the purpose!
